### PR TITLE
fixed module not found error

### DIFF
--- a/PyPI/Package/src/webui/load_library.py
+++ b/PyPI/Package/src/webui/load_library.py
@@ -56,7 +56,7 @@ def _download_library():
 
 
 # Load WebUI Dynamic Library
-def _load_library() -> CDLL:
+def load_library() -> CDLL:
     library: CDLL | None = None
     lib_path = _get_library_path()
     if not os.path.exists(lib_path):

--- a/PyPI/Package/src/webui/webui.py
+++ b/PyPI/Package/src/webui/webui.py
@@ -16,7 +16,7 @@ from typing import Callable, Optional
 from ctypes import *
 
 # Import all the raw bindings
-import webui_bindings as _raw
+from . import webui_bindings as _raw
 
 
 

--- a/PyPI/Package/src/webui/webui_bindings.py
+++ b/PyPI/Package/src/webui/webui_bindings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from ctypes import *
-from load_library import _load_library
+from . import load_library as ll
 import enum
 
 # WebUI Library
@@ -15,7 +15,7 @@ import enum
 
 
 # Loading the library in for bindings
-lib: CDLL | None = _load_library()
+lib: CDLL | None = ll.load_library()
 if lib is None:
     print('WebUI Dynamic Library not found.')
     sys.exit(1)


### PR DESCRIPTION
fixed the imports not being relative. When I downloaded the new release to test, it threw `module not found` errors even though the files themselves were there. I've tested this build locally this time, through pip and it worked fine now.