### PR TITLE
fixed cp command still calling webui-2 instead of libwebui-2 in "minimal"

### DIFF
--- a/PyPI/Package/src/webui/bootstrap.sh
+++ b/PyPI/Package/src/webui/bootstrap.sh
@@ -123,7 +123,7 @@ if [[ "$1" == "minimal" ]]; then
 
     # Copy library
     mkdir -p "$FILENAME" 2>/dev/null
-    cp -f "cache/$FILENAME/webui-2.${EXT}" "$FILENAME/webui-2.${EXT}"
+    cp -f "cache/$FILENAME/libwebui-2.${EXT}" "$FILENAME/libwebui-2.${EXT}"
 
     # Remove cache folder
     rm -rf "cache"


### PR DESCRIPTION
If you start a new project on Linux specifically in my case, "minimal" for the bootstrap runs and fails because the copy command still has "webui-2.so" as the file rather "libwebui-2.so" that nightly now uses.

So far every time I run on MacOS option 1 in the script runs so it renames the contents to webui-2.dylib but if it were to run with the "minimal" argument, it would have the same the problem I see on Linux.

This was the only line I had to change to make my program run (besides from the commits that have already been made) and double checked on MacOS to see why it was still working. I believe this is the only thing needed. We should prep/push for next release to fix the PyPi release soon.